### PR TITLE
bugfix: m/M commands can have implicit lineTo

### DIFF
--- a/packages/svg-deserializer/index.js
+++ b/packages/svg-deserializer/index.js
@@ -947,7 +947,12 @@ sax.SAXParser.prototype.codify = function (group) {
                 code += indent + 'var ' + pn + ' = new CSG.Path2D([[' + this.svg2cagX(cx) + ',' + this.svg2cagY(cy) + ']],false);\n'
                 sx = cx; sy = cy
               }
-              break
+            // optional implicit relative lineTo (cf SVG spec 8.3.2)
+              while (pts.length >= 2) {
+                cx = cx + parseFloat(pts.shift())
+                cy = cy + parseFloat(pts.shift())
+                code += indent + pn + ' = ' + pn + '.appendPoint([' + this.svg2cagX(cx) + ',' + this.svg2cagY(cy) + ']);\n'
+              }
               break
             case 'M': // absolute move to X,Y
             // close the previous path
@@ -964,6 +969,12 @@ sax.SAXParser.prototype.codify = function (group) {
                 code += indent + 'var ' + pn + ' = new CSG.Path2D([[' + this.svg2cagX(cx) + ',' + this.svg2cagY(cy) + ']],false);\n'
                 sx = cx; sy = cy
               }
+            // optional implicit absolute lineTo (cf SVG spec 8.3.2)
+              while (pts.length >= 2) {
+                cx = parseFloat(pts.shift())
+                cy = parseFloat(pts.shift())
+                code += indent + pn + ' = ' + pn + '.appendPoint([' + this.svg2cagX(cx) + ',' + this.svg2cagY(cy) + ']);\n'
+              }              
               break
             case 'a': // relative elliptical arc
               while (pts.length >= 7) {


### PR DESCRIPTION
I ran into a bug with some inkscape created SVG.
After a bit of debugging I realized that the current deserializer does not implement "implicit lineTo".

As per SVG spec :

https://www.w3.org/TR/SVG/paths.html#PathDataMovetoCommands

> Start a new sub-path at the given (x,y) coordinate. M (uppercase) indicates that absolute coordinates will follow; m (lowercase) indicates that relative coordinates will follow. **If a moveto is followed by multiple pairs of coordinates, the subsequent pairs are treated as implicit lineto commands**. Hence, implicit lineto commands will be relative if the moveto is relative, and absolute if the moveto is absolute. If a relative moveto (m) appears as the first element of the path, then it is treated as a pair of absolute coordinates. In this case, subsequent pairs of coordinates are treated as relative even though the initial moveto is interpreted as an absolute moveto.

This PR implements this (and fixed my bug)