### PR TITLE
docs(README): updated version badge

### DIFF
--- a/packages/amf-deserializer/README.md
+++ b/packages/amf-deserializer/README.md
@@ -2,12 +2,12 @@
 
 > amf deserializer for the jscad project
 
-[![GitHub version](https://badge.fury.io/gh/jscad%40jscad%2Famf-deserializer.svg)](https://badge.fury.io/gh/jscad%40jscad%2Famf-deserializer)
+[![npm version](https://badge.fury.io/js/%40jscad%2Famf-deserializer.svg)](https://badge.fury.io/js/%40jscad%2Famf-deserializer)
 [![Build Status](https://travis-ci.org/jscad/io.svg)](https://travis-ci.org/jscad/amf-deserializer)
 
 ## Overview
 
-This deserializer converts raw amf data to jscad code (that can be evaluated to CSG/CAG). 
+This deserializer converts raw amf data to jscad code (that can be evaluated to CSG/CAG).
 
 ## Table of Contents
 

--- a/packages/amf-serializer/README.md
+++ b/packages/amf-serializer/README.md
@@ -2,7 +2,7 @@
 
 > amf serializer for the jscad project (from CSG)
 
-[![GitHub version](https://badge.fury.io/gh/jscad%40jscad%2Famf-serializer.svg)](https://badge.fury.io/gh/jscad%40jscad%2Famf-serializer)
+[![npm version](https://badge.fury.io/js/%40jscad%2Famf-serializer.svg)](https://badge.fury.io/js/%40jscad%2Famf-serializer)
 [![Build Status](https://travis-ci.org/jscad/io.svg)](https://travis-ci.org/jscad/amf-serializer)
 
 ## Overview

--- a/packages/dxf-serializer/README.md
+++ b/packages/dxf-serializer/README.md
@@ -1,8 +1,8 @@
 ## @jscad/dxf-serializer
 
-> xdf serializer for the jscad project (from CSG)
+> dxf serializer for the jscad project (from CSG)
 
-[![GitHub version](https://badge.fury.io/gh/jscad%40jscad%2Fdxf-serializer.svg)](https://badge.fury.io/gh/jscad%40jscad%2Fdxf-serializer)
+[![npm version](https://badge.fury.io/js/%40jscad%2Fdxf-serializer.svg)](https://badge.fury.io/js/%40jscad%2Fdxf-serializer)
 [![Build Status](https://travis-ci.org/jscad/io.svg)](https://travis-ci.org/jscad/dxf-serializer)
 
 ## Overview

--- a/packages/gcode-deserializer/README.md
+++ b/packages/gcode-deserializer/README.md
@@ -2,12 +2,12 @@
 
 > gcode deserializer for the jscad project
 
-[![GitHub version](https://badge.fury.io/gh/jscad%40jscad%2Fgcode-serializer.svg)](https://badge.fury.io/gh/jscad%40jscad%2Fgcode-deserializer)
+[![npm version](https://badge.fury.io/js/%40jscad%2Fgcode-deserializer.svg)](https://badge.fury.io/js/%40jscad%2Fgcode-deserializer)
 [![Build Status](https://travis-ci.org/jscad/io.svg)](https://travis-ci.org/jscad/gcode-deserializer)
 
 ## Overview
 
-This deserializer converts raw gcode data to jscad code (that can be evaluated to CSG/CAG). 
+This deserializer converts raw gcode data to jscad code (that can be evaluated to CSG/CAG).
 
 ## Table of Contents
 

--- a/packages/io-utils/README.md
+++ b/packages/io-utils/README.md
@@ -2,7 +2,7 @@
 
 > input/output handling utilities
 
-[![GitHub version](https://badge.fury.io/gh/jscad%40jscad%2Fio-utils.svg)](https://badge.fury.io/gh/jscad%40jscad%2Fio-utils)
+[![npm version](https://badge.fury.io/js/%40jscad%2Fio-utils.svg)](https://badge.fury.io/js/%40jscad%2Fio-utils)
 [![Build Status](https://travis-ci.org/jscad/io.svg)](https://travis-ci.org/jscad/io-utils)
 
 ## Overview

--- a/packages/io/README.md
+++ b/packages/io/README.md
@@ -2,7 +2,7 @@
 
 ## input output formats handling for the jscad project
 
-[![GitHub version](https://badge.fury.io/gh/jscad%2Fio.svg)](https://badge.fury.io/gh/jscad%2Fio)
+[![npm version](https://badge.fury.io/js/%40jscad%2Fio.svg)](https://badge.fury.io/js/%40jscad%2Fio)
 
 ## Overview
 

--- a/packages/json-deserializer/README.md
+++ b/packages/json-deserializer/README.md
@@ -2,12 +2,12 @@
 
 > json deserializer for the jscad project
 
-[![GitHub version](https://badge.fury.io/gh/jscad%40jscad%2Fjson-deserializer.svg)](https://badge.fury.io/gh/jscad%40jscad%2Fjson-deserializer)
+[![npm version](https://badge.fury.io/js/%40jscad%2Fjson-deserializer.svg)](https://badge.fury.io/js/%40jscad%2Fjson-deserializer)
 [![Build Status](https://travis-ci.org/jscad/io.svg)](https://travis-ci.org/jscad/json-deserializer)
 
 ## Overview
 
-This deserializer converts raw json data to jscad code (that can be evaluated to CSG/CAG). 
+This deserializer converts raw json data to jscad code (that can be evaluated to CSG/CAG).
 
 ## Table of Contents
 

--- a/packages/json-serializer/README.md
+++ b/packages/json-serializer/README.md
@@ -2,7 +2,7 @@
 
 > json serializer for the jscad project (from CSG)
 
-[![GitHub version](https://badge.fury.io/gh/jscad%40jscad%2Fjson-serializer.svg)](https://badge.fury.io/gh/jscad%40jscad%2Fjson-serializer)
+[![npm version](https://badge.fury.io/js/%40jscad%2Fjson-serializer.svg)](https://badge.fury.io/js/%40jscad%2Fjson-serializer)
 [![Build Status](https://travis-ci.org/jscad/io.svg)](https://travis-ci.org/jscad/json-serializer)
 
 ## Overview

--- a/packages/obj-deserializer/README.md
+++ b/packages/obj-deserializer/README.md
@@ -2,12 +2,12 @@
 
 > obj deserializer for the jscad project
 
-[![GitHub version](https://badge.fury.io/gh/jscad%40jscad%2Fobj-deserializer.svg)](https://badge.fury.io/gh/jscad%40jscad%2Fobj-deserializer)
+[![npm version](https://badge.fury.io/js/%40jscad%2Fobj-deserializer.svg)](https://badge.fury.io/js/%40jscad%2Fobj-deserializer)
 [![Build Status](https://travis-ci.org/jscad/io.svg)](https://travis-ci.org/jscad/obj-deserializer)
 
 ## Overview
 
-This deserializer converts raw obj data to jscad code (that can be evaluated to CSG/CAG). 
+This deserializer converts raw obj data to jscad code (that can be evaluated to CSG/CAG).
 
 ## Table of Contents
 

--- a/packages/stl-deserializer/README.md
+++ b/packages/stl-deserializer/README.md
@@ -2,12 +2,12 @@
 
 > stl deserializer for the jscad project
 
-[![GitHub version](https://badge.fury.io/gh/jscad%40jscad%2Fstl-deserializer.svg)](https://badge.fury.io/gh/jscad%40jscad%2Fstl-deserializer)
+[![npm version](https://badge.fury.io/js/%40jscad%2Fstl-deserializer.svg)](https://badge.fury.io/js/%40jscad%2Fstl-deserializer)
 [![Build Status](https://travis-ci.org/jscad/io.svg)](https://travis-ci.org/jscad/stl-deserializer)
 
 ## Overview
 
-This deserializer converts raw stl data to jscad code (that can be evaluated to CSG/CAG). 
+This deserializer converts raw stl data to jscad code (that can be evaluated to CSG/CAG).
 
 ## Table of Contents
 

--- a/packages/stl-serializer/README.md
+++ b/packages/stl-serializer/README.md
@@ -2,7 +2,7 @@
 
 > stl serializer for the jscad project (from CSG)
 
-[![GitHub version](https://badge.fury.io/gh/jscad%40jscad%2Fstl-serializer.svg)](https://badge.fury.io/gh/jscad%40jscad%2Fstl-serializer)
+[![npm version](https://badge.fury.io/js/%40jscad%2Fstl-serializer.svg)](https://badge.fury.io/js/%40jscad%2Fstl-serializer)
 [![Build Status](https://travis-ci.org/jscad/io.svg)](https://travis-ci.org/jscad/stl-serializer)
 
 ## Overview

--- a/packages/svg-deserializer/README.md
+++ b/packages/svg-deserializer/README.md
@@ -2,7 +2,7 @@
 
 > svg deserializer for the jscad project
 
-[![GitHub version](https://badge.fury.io/gh/jscad%40jscad%2Fsvg-deserializer.svg)](https://badge.fury.io/gh/jscad%40jscad%2Fsvg-deserializer)
+[![npm version](https://badge.fury.io/js/%40jscad%2Fsvg-deserializer.svg)](https://badge.fury.io/js/%40jscad%2Fsvg-deserializer)
 [![Build Status](https://travis-ci.org/jscad/io.svg)](https://travis-ci.org/jscad/svg-deserializer)
 
 ## Overview

--- a/packages/svg-serializer/README.md
+++ b/packages/svg-serializer/README.md
@@ -2,7 +2,7 @@
 
 > svg serializer for the jscad project (from CSG)
 
-[![GitHub version](https://badge.fury.io/gh/jscad%40jscad%2Fsvg-serializer.svg)](https://badge.fury.io/gh/jscad%40jscad%2Fsvg-serializer)
+[![npm version](https://badge.fury.io/js/%40jscad%2Fsvg-serializer.svg)](https://badge.fury.io/js/%40jscad%2Fsvg-serializer)
 [![Build Status](https://travis-ci.org/jscad/io.svg)](https://travis-ci.org/jscad/svg-serializer)
 
 ## Overview

--- a/packages/x3d-serializer/README.md
+++ b/packages/x3d-serializer/README.md
@@ -2,7 +2,7 @@
 
 > x3d serializer for the jscad project (from CSG)
 
-[![GitHub version](https://badge.fury.io/gh/jscad%40jscad%2Fx3d-serializer.svg)](https://badge.fury.io/gh/jscad%40jscad%2Fx3d-serializer)
+[![npm version](https://badge.fury.io/js/%40jscad%2Fx3d-serializer.svg)](https://badge.fury.io/js/%40jscad%2Fx3d-serializer)
 [![Build Status](https://travis-ci.org/jscad/io.svg)](https://travis-ci.org/jscad/x3d-serializer)
 
 ## Overview


### PR DESCRIPTION
This pr replaces the old version badges in each readme with a correct one pointing to the npm packages