### PR TITLE
feat(deserialize): add wrapper function around all deserializers

### DIFF
--- a/packages/io/index.js
+++ b/packages/io/index.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const {makeBlob} = require('@jscad/io-utils')
 
 const amfSerializer = require('@jscad/amf-serializer')
@@ -17,12 +18,16 @@ const svgDeSerializer = require('@jscad/svg-deserializer')
 // api function that wraps all deserializers , to be used as part of jscad itself
 // TODO: should this return a csg by default ? (YES)
 // TODO: should this also handle file path resolution & reading : NO because it conflates issues, YES because of convenience, for browser UI only)
-function deserialize (input, filename, options) {
+// TODO: how to handle both Node.js and browser envs
+function deserialize (input, options) {
   options = Object.assign({}, options, {output: 'CSG'})
-  const {format} = options
+  const filename = path.basename()
+  const format = path.extname(input) || options.format
+
   if (!format) {
-    throw new Error('no input format specified, cannot load data')
+    throw new Error('no input format specified, and none present in the input path, cannot load data')
   }
+
   const deserializers = {
     amf: amfDeSerializer,
     gcode: gcodeDeSerializer,

--- a/packages/io/index.js
+++ b/packages/io/index.js
@@ -14,6 +14,28 @@ const objDeSerializer = require('@jscad/obj-deserializer')
 const stlDeSerializer = require('@jscad/stl-deserializer')
 const svgDeSerializer = require('@jscad/svg-deserializer')
 
+// api function that wraps all deserializers , to be used as part of jscad itself
+// TODO: should this return a csg by default ? (YES)
+// TODO: should this also handle file path resolution & reading : NO because it conflates issues, YES because of convenience, for browser UI only)
+function deserialize (input, filename, options) {
+  options = Object.assign({}, options, {output: 'CSG'})
+  const {format} = options
+  if (!format) {
+    throw new Error('no input format specified, cannot load data')
+  }
+  const deserializers = {
+    amf: amfDeSerializer,
+    gcode: gcodeDeSerializer,
+    json: jsonDeSerializer,
+    obj: objDeSerializer,
+    stl: stlDeSerializer,
+    svg: svgSerializer
+  }
+  const deserializer = deserializers[format]
+  const output = deserializer.deserialize(input, filename, options)
+  return output
+}
+
 module.exports = {
   makeBlob,
   amfSerializer,
@@ -28,9 +50,11 @@ module.exports = {
   jsonDeSerializer,
   objDeSerializer,
   stlDeSerializer,
-  svgDeSerializer
+  svgDeSerializer,
+
+  deserialize
 }
-/*export {makeBlob} from './utils/Blob'
+/* export {makeBlob} from './utils/Blob'
 
 import * as CAGToDxf from './serializers/CAGToDxf'
 import * as CAGToJson from './serializers/CAGToJson'
@@ -48,4 +72,4 @@ export {parseGCode} from './deserializers/parseGCode'
 export {parseJSON} from './deserializers/parseJSON'
 export {parseOBJ} from './deserializers/parseOBJ'
 export {parseSTL} from './deserializers/parseSTL'
-export {parseSVG} from './deserializers/parseSVG'*/
+export {parseSVG} from './deserializers/parseSVG' */


### PR DESCRIPTION
WORK IN PROGRESS DO NOT MERGE !! 

This PR adds a wrapper function around all deserizers to provide a more convienient API , possibly to be used directly inside jscad scripts
something like 
```javascript
const myCSG = deserialize ('foo.stl')
```