### PR TITLE
docs(README): fixed bad usage examples in all relevant READMEs

### DIFF
--- a/packages/amf-deserializer/README.md
+++ b/packages/amf-deserializer/README.md
@@ -30,8 +30,7 @@ npm install @jscad/amf-deserializer
 const amfDeSerializer = require('@jscad/amf-deserializer')
 
 const rawData = fs.readFileSync('PATH/TO/file.amf')
-const csgData = amfDeSerializer(rawData)
-
+const csgData = amfDeSerializer.deserialize(rawData, undefined, {output: 'csg'})
 ```
 
 

--- a/packages/amf-serializer/README.md
+++ b/packages/amf-serializer/README.md
@@ -31,7 +31,7 @@ npm install @jscad/amf-serializer
 ```javascript
 const amfSerializer = require('@jscad/amf-serializer')
 
-const rawData = amfSerializer(CSGObject)
+const rawData = amfSerializer.serialize(CSGObject)
 
 //in browser (with browserify etc)
 const blob = new Blob(rawData)

--- a/packages/dxf-serializer/README.md
+++ b/packages/dxf-serializer/README.md
@@ -29,9 +29,9 @@ npm install @jscad/dxf-serializer
 
 
 ```javascript
-const dxfSerializer = require('@jscad/dxf-serializer').serialize
+const dxfSerializer = require('@jscad/dxf-serializer')
 
-const rawData = dxfSerializer(CSGObject)
+const rawData = dxfSerializer.serialize(CSGObject)
 
 //in browser (with browserify etc)
 const blob = new Blob(rawData)

--- a/packages/json-deserializer/README.md
+++ b/packages/json-deserializer/README.md
@@ -30,7 +30,7 @@ npm install @jscad/json-deserializer
 const jsonDeSerializer = require('@jscad/json-deserializer')
 
 const rawData = fs.readFileSync('PATH/TO/file.json')
-const csgData = jsonDeSerializer(rawData)
+const csgData = jsonDeSerializer.deserialize(rawData, undefined, {output: 'csg'})
 
 ```
 

--- a/packages/json-serializer/README.md
+++ b/packages/json-serializer/README.md
@@ -31,7 +31,7 @@ npm install @jscad/json-serializer
 ```javascript
 const jsonSerializer = require('@jscad/json-serializer')
 
-const rawData = jsonSerializer(CSGObject)
+const rawData = jsonSerializer.serialize(CSGObject)
 
 //in browser (with browserify etc)
 const blob = new Blob(rawData)

--- a/packages/obj-deserializer/README.md
+++ b/packages/obj-deserializer/README.md
@@ -30,7 +30,7 @@ npm install @jscad/obj-deserializer
 const objDeSerializer = require('@jscad/obj-deserializer')
 
 const rawData = fs.readFileSync('PATH/TO/file.obj')
-const csgData = objDeSerializer(rawData)
+const csgData = objDeSerializer.deserialize(rawData, undefined, {output: 'csg'})
 
 ```
 

--- a/packages/stl-deserializer/README.md
+++ b/packages/stl-deserializer/README.md
@@ -30,7 +30,7 @@ npm install @jscad/stl-deserializer
 const stlDeSerializer = require('@jscad/stl-deserializer')
 
 const rawData = fs.readFileSync('PATH/TO/file.stl')
-const csgData = stlDeSerializer(rawData)
+const csgData = stlDeSerializer.deserialize(rawData, undefined, {output: 'csg'})
 
 ```
 

--- a/packages/stl-serializer/README.md
+++ b/packages/stl-serializer/README.md
@@ -32,7 +32,7 @@ npm install @jscad/stl-serializer
 ```javascript
 const stlSerializer = require('@jscad/stl-serializer')
 
-const rawData = stlSerializer(CSGObject)
+const rawData = stlSerializer.serializ(CSGObject)
 
 //in browser (with browserify etc)
 const blob = new Blob(rawData)

--- a/packages/svg-deserializer/README.md
+++ b/packages/svg-deserializer/README.md
@@ -32,7 +32,7 @@ npm install @jscad/svg-deserializer
 const svgDeSerializer = require('@jscad/svg-deserializer').deserialize
 
 const rawData = fs.readFileSync('PATH/TO/file.svg')
-const csgData = svgDeSerializer(rawData)
+const cagData = svgDeSerializer.deserialize(rawData, undefined, {output: 'csg'})
 
 ```
 

--- a/packages/svg-serializer/README.md
+++ b/packages/svg-serializer/README.md
@@ -32,7 +32,7 @@ npm install @jscad/svg-serializer
 ```javascript
 const svgSerializer = require('@jscad/svg-serializer')
 
-const rawData = svgSerializer(CAGObject)
+const rawData = svgSerializer.serialize(CAGObject)
 
 //in browser (with browserify etc)
 const blob = new Blob(rawData)

--- a/packages/x3d-serializer/README.md
+++ b/packages/x3d-serializer/README.md
@@ -31,7 +31,7 @@ npm install @jscad/x3d-serializer
 ```javascript
 const x3dSerializer = require('@jscad/x3d-serializer')
 
-const rawData = x3dSerializer(CSGObject)
+const rawData = x3dSerializer.serialize(CSGObject)
 
 //in browser (with browserify etc)
 const blob = new Blob(rawData)


### PR DESCRIPTION
This fixes all the bad examples for de/serializers