### PR TITLE
Corrected EOF group as well as test cases

### DIFF
--- a/packages/dxf-serializer/index.js
+++ b/packages/dxf-serializer/index.js
@@ -49,6 +49,7 @@ ${dxfTables(options)}
 ${dxfBlocks(options)}
 ${dxfEntities(objects, options)}
 ${dxfObjects(options)}
+  0
 EOF
 `
   return [dxfContent]

--- a/packages/dxf-serializer/tests/testCagToDxf.js
+++ b/packages/dxf-serializer/tests/testCagToDxf.js
@@ -59,6 +59,7 @@ ENTITIES
   0
 ENDSEC
 ${dxfObjects({})}
+  0
 EOF
 `
 
@@ -111,6 +112,7 @@ AcDbPolyline
   0
 ENDSEC
 ${dxfObjects({})}
+  0
 EOF
 `
 
@@ -163,6 +165,7 @@ AcDbPolyline
   0
 ENDSEC
 ${dxfObjects({})}
+  0
 EOF
 `
 
@@ -251,6 +254,7 @@ AcDbPolyline
   0
 ENDSEC
 ${dxfObjects({})}
+  0
 EOF
 `
 
@@ -363,6 +367,7 @@ AcDbEntity
   0
 ENDSEC
 ${dxfObjects({})}
+  0
 EOF
 `
 

--- a/packages/dxf-serializer/tests/testCsgToDxf.js
+++ b/packages/dxf-serializer/tests/testCsgToDxf.js
@@ -50,6 +50,7 @@ ENTITIES
   0
 ENDSEC
 ${dxfObjects({})}
+  0
 EOF
 `
 
@@ -282,6 +283,7 @@ AcDbFace
   0
 ENDSEC
 ${dxfObjects({})}
+  0
 EOF
 `
 
@@ -962,6 +964,7 @@ AcDb3dPolylineVertex
   0
 ENDSEC
 ${dxfObjects({})}
+  0
 EOF
 `
 

--- a/packages/dxf-serializer/tests/testPathToDxf.js
+++ b/packages/dxf-serializer/tests/testPathToDxf.js
@@ -43,6 +43,7 @@ ENTITIES
   0
 ENDSEC
 ${dxfObjects({})}
+  0
 EOF
 `
 
@@ -99,6 +100,7 @@ AcDbPolyline
   0
 ENDSEC
 ${dxfObjects({})}
+  0
 EOF
 `
 
@@ -195,6 +197,7 @@ AcDbPolyline
   0
 ENDSEC
 ${dxfObjects({})}
+  0
 EOF
 `
 


### PR DESCRIPTION
OH BOY!

The last entity for EOF was incorrect. The group code was missing. The correct format is:

```
  0
EOF
```

The fix was trivial but all so important.