### PR TITLE
DXF layers fix

### DIFF
--- a/packages/dxf-deserializer/test/test-2d-translation.js
+++ b/packages/dxf-deserializer/test/test-2d-translation.js
@@ -11,15 +11,16 @@ const { deserialize } = require( '../index' )
 // Test suite for DXF deserialization (import)
 //
 test('ASCII DXF 2D Entities translated to JSCAD Scripts', t => {
-// DXF empty source, translate to main and helper functions
+// DXF empty source, translate to main and helper functions and layer0
   let dxf1 = ''
-  let src1 = deserialize(dxf1,'dxf1 test',{output: 'jscad'})
+  let src1 = deserialize(dxf1, 'dxf1 test', {output: 'jscad'})
   let ss1 = src1.split("\n")
-  t.is(ss1.length,22)
+  t.is(ss1.length, 25)
   t.true(src1.indexOf('main()') > 0)
   t.true(src1.indexOf('createVertex(') > 0)
   t.true(src1.indexOf('createPlane(') > 0)
   t.true(src1.indexOf('createPolygon(') > 0)
+  t.true(src1.indexOf('function layer0(') > 0)
 
 // DXF CIRCLE, translates to script with CAG.circle
   let dxf2 = `0
@@ -341,6 +342,59 @@ ENDSEC`
   t.true(src2.indexOf('CSG.Path2D(') > 0)
   t.true(src2.indexOf('appendPoint(') > 0)
   t.true(src2.indexOf('appendArc(') > 0)
+
+// DXF with two labels (ASCII and KANJI) with one entity (CIRCLE), translates to script with three layers
+  let dxf3 = `0
+TABLES
+0
+TABLE
+0
+LAYER
+2
+ASCII
+70
+1
+0
+ENDTAB
+0
+TABLE
+0
+LAYER
+2
+漢字
+70
+1
+0
+ENDTAB
+0
+ENDSEC
+0
+SECTION
+2
+ENTITIES
+0
+CIRCLE
+  8
+漢字
+ 10
+7.5
+ 20
+17.5
+ 30
+0.0
+ 40
+2.5
+0
+SEQEND
+0
+ENDSEC`
+  let src3 = deserialize(dxf3,'dxf3-test',{output: 'jscad'})
+  let ss3 = src3.split("\n")
+  t.is(ss3.length, 32)
+  t.true(src3.indexOf('function layer0(') > 0)
+  t.true(src3.indexOf('function layer1(') > 0)
+  t.true(src3.indexOf('function layer2(') > 0)
+  t.true(src3.indexOf('CAG.circle') > 0)
 
 })
 

--- a/packages/dxf-deserializer/translate.js
+++ b/packages/dxf-deserializer/translate.js
@@ -386,6 +386,7 @@ function findLayer0 (layers) {
   }
   // this DXF did not specify so create
   let layer = {type: 'layer'}
+  layer['lnam'] = 'layer0'
   layer['name'] = '0'
   layer['lscl'] = 1.0
   layer['visb'] = 0
@@ -677,9 +678,9 @@ function translateCurrent (obj, layers, parts, options) {
 // translate the given layer into a wrapper function for the previous translated objects
 //
 function translateLayer (layer) {
-  let name = layer['name'] || 'Unknown'
+  let name = layer['lnam'] || 'Unknown'
 
-  let script = `function layer${name}() {
+  let script = `function ${name}() {
 `
   for (let object of layer['objects']) {
     script += object['script']
@@ -718,6 +719,8 @@ const translateAsciiDxf = function (reader, options) {
   let objects = [] // the list of objects translated
   let numobjs = 0
 
+  findLayer0(layers)
+
   let p = null
   for (let obj of reader.objstack) {
     p = null
@@ -749,6 +752,7 @@ const translateAsciiDxf = function (reader, options) {
         parts = []
         // save the layer for later reference
         obj['objects'] = [] // with a list of objects
+        obj['lnam'] = 'layer' + layers.length
         layers.push(obj)
         break
       case 'variable':
@@ -855,8 +859,8 @@ const translateAsciiDxf = function (reader, options) {
   let script = 'function main() {\n  let layers = []\n  return layers.concat('
   layers.forEach(
     function (layer) {
-      let name = layer['name'] || 'Unknown'
-      script += `layer${name}(),`
+      let name = layer['lnam'] || 'Unknown'
+      script += `${name}(),`
     }
   )
   script += '[])\n}\n'


### PR DESCRIPTION
This corrects an assumption that layer names were usable as strings in JavaScript. As reported in OpenJSCAD.org Import DXF error #372, Chinese characters produced invalid function names when translating.