### PR TITLE
fix: corrected polygonToTriangles when polygon has less then 3 vertices

### DIFF
--- a/packages/dxf-serializer/index.js
+++ b/packages/dxf-serializer/index.js
@@ -229,7 +229,7 @@ const PolygonsTo3DFaces = function (csg, options) {
 // NOTE: This only works for CONVEX polygons
 const polygonToTriangles = (polygon) => {
   let length = polygon.vertices.length - 2
-  if (length <= 1) return [polygon]
+  if (length < 1) return []
 
   let pivot = polygon.vertices[0]
   let triangles = []


### PR DESCRIPTION
As part of enabling DXF output of 3D objects via OpenJSCAD.org, this bug was found. Obviously, the 3D objects are ill formed but the polygonToTriangles() function had a bug.

I'm happy to say that almost all examples can be converted to DXF now. The exception is the Globe example, which will take some time to analyize due to special functions.