### PR TITLE
Update STL serialize with more V2 changes

### DIFF
--- a/packages/stl-serializer/CSGToStla.js
+++ b/packages/stl-serializer/CSGToStla.js
@@ -31,11 +31,11 @@ const convertToFacets = (object, options) => {
 }
 
 const vector3DtoStlString = (v) => {
-  return `${v._x} ${v._y} ${v._z}`
+  return `${v[0]} ${v[1]} ${v[2]}`
 }
 
 const vertextoStlString = (vertex) => {
-  return `vertex ${vector3DtoStlString(vertex.pos)}`
+  return `vertex ${vector3DtoStlString(vertex)}`
 }
 
 const convertToFacet = (polygon) => {
@@ -44,7 +44,7 @@ const convertToFacet = (polygon) => {
     // STL requires triangular polygons. If our polygon has more vertices, create multiple triangles:
     let firstVertexStl = vertextoStlString(polygon.vertices[0])
     for (let i = 0; i < polygon.vertices.length - 2; i++) {
-      let facet = `facet normal ${vector3DtoStlString(polygon.plane.normal)}
+      let facet = `facet normal ${vector3DtoStlString(polygon.plane)}
 outer loop
 ${firstVertexStl}
 ${vertextoStlString(polygon.vertices[i + 1])}

--- a/packages/stl-serializer/CSGToStlb.js
+++ b/packages/stl-serializer/CSGToStlb.js
@@ -54,17 +54,17 @@ const serializeBinary = (objects, options) => {
     object.polygons.forEach(function (polygon) {
       let numvertices = polygon.vertices.length
       for (let i = 0; i < numvertices - 2; i++) {
-        let normal = polygon.plane.normal
-        triangleFloat32array[0] = normal._x
-        triangleFloat32array[1] = normal._y
-        triangleFloat32array[2] = normal._z
+        let normal = polygon.plane
+        triangleFloat32array[0] = normal[0]
+        triangleFloat32array[1] = normal[1]
+        triangleFloat32array[2] = normal[2]
         let arindex = 3
         for (let v = 0; v < 3; v++) {
           let vv = v + ((v > 0) ? i : 0)
-          let vertexpos = polygon.vertices[vv].pos
-          triangleFloat32array[arindex++] = vertexpos._x
-          triangleFloat32array[arindex++] = vertexpos._y
-          triangleFloat32array[arindex++] = vertexpos._z
+          let vertexpos = polygon.vertices[vv]
+          triangleFloat32array[arindex++] = vertexpos[0]
+          triangleFloat32array[arindex++] = vertexpos[1]
+          triangleFloat32array[arindex++] = vertexpos[2]
         }
         triangleUint16array[0] = 0
         // copy the triangle into allTrianglesBuffer:


### PR DESCRIPTION
to access polygon verticies and plane normals using V2 APIs

array access instead of using _pos and _x, _y, and _z

treat planes as vec4 instead of an object with a property called .normal